### PR TITLE
Add method for loading a single cache file

### DIFF
--- a/DBFileReaderLib/HotfixReader.cs
+++ b/DBFileReaderLib/HotfixReader.cs
@@ -43,19 +43,23 @@ namespace DBFileReaderLib
         {
             foreach (var file in files)
             {
-                if (!File.Exists(file))
-                    continue;
-
-                // parse the new cache
-                var reader = new HTFXReader(file);
-                if (reader.BuildId != BuildId)
-                    continue;
-
-                // add additional hotfix entries
-                _reader.Combine(reader);
+                CombineCache(file);
             }
         }
+        
+        public void CombineCache(string file)
+        {
+            if (!File.Exists(file))
+                return;
 
+            // parse the new cache
+            var reader = new HTFXReader(file);
+            if (reader.BuildId != BuildId)
+                return;
+
+            // add additional hotfix entries
+            _reader.Combine(reader);
+        }
 
         protected virtual void ReadHotfixes<T>(IDictionary<int, T> storage, DBReader dbReader) where T : class, new()
         {


### PR DESCRIPTION
Helps prevent WoW.tools's DBC backend having to reload literally all of the caches for a build each time a new one is submitted.