### PR TITLE
Feature/expose hotfix processing

### DIFF
--- a/DBCD/DBCDStorage.cs
+++ b/DBCD/DBCDStorage.cs
@@ -74,6 +74,7 @@ namespace DBCD
 
         Dictionary<ulong, int> GetEncryptedSections();
         IDBCDStorage ApplyingHotfixes(HotfixReader hotfixReader);
+        IDBCDStorage ApplyingHotfixes(HotfixReader hotfixReader, HotfixReader.RowProcessor processor);
     }
 
     public class DBCDStorage<T> : ReadOnlyDictionary<int, DBCDRow>, IDBCDStorage where T : class, new()
@@ -103,9 +104,14 @@ namespace DBCD
 
         public IDBCDStorage ApplyingHotfixes(HotfixReader hotfixReader)
         {
+            return this.ApplyingHotfixes(hotfixReader, null);
+        }
+
+        public IDBCDStorage ApplyingHotfixes(HotfixReader hotfixReader, HotfixReader.RowProcessor processor)
+        {
             var mutableStorage = this.storage.ToDictionary(k => k.Key, v => v.Value);
 
-            hotfixReader.ApplyHotfixes(mutableStorage, this.reader);
+            hotfixReader.ApplyHotfixes(mutableStorage, this.reader, processor);
 
             return new DBCDStorage<T>(this.reader, new ReadOnlyDictionary<int, T>(mutableStorage), this.info);
         }

--- a/DBFileReaderLib/Common/HTFXStructs.cs
+++ b/DBFileReaderLib/Common/HTFXStructs.cs
@@ -2,14 +2,14 @@
 
 namespace DBFileReaderLib.Common
 {
-    interface IHotfixEntry
+    public interface IHotfixEntry
     {
         int PushId { get; }
         int DataSize { get; }
         uint TableHash { get; }
         int RecordId { get; }
         bool IsValid { get; }
-    }
+    }    
 
     struct HotfixEntryV1 : IHotfixEntry
     {

--- a/DBFileReaderLib/Common/HTFXStructs.cs
+++ b/DBFileReaderLib/Common/HTFXStructs.cs
@@ -1,5 +1,7 @@
 ﻿#pragma warning disable CS0169
 
+using System.Runtime.InteropServices;
+
 namespace DBFileReaderLib.Common
 {
     public interface IHotfixEntry
@@ -9,8 +11,9 @@ namespace DBFileReaderLib.Common
         uint TableHash { get; }
         int RecordId { get; }
         bool IsValid { get; }
-    }    
+    }
 
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct HotfixEntryV1 : IHotfixEntry
     {
         public int PushId { get; }
@@ -22,6 +25,7 @@ namespace DBFileReaderLib.Common
         private readonly byte pad1, pad2, pad3;
     }
 
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct HotfixEntryV2 : IHotfixEntry
     {
         public uint Version { get; }
@@ -34,14 +38,15 @@ namespace DBFileReaderLib.Common
         private readonly byte pad1, pad2, pad3;
     }
 
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct HotfixEntryV7 : IHotfixEntry
     {
         public int PushId { get; }
         public uint TableHash { get; }
         public int RecordId { get; }
         public int DataSize { get; }
-        public bool IsValid { get; }
+        public bool IsValid => op == 1;
 
-        private readonly byte pad1, pad2, pad3;
+        private readonly byte op, pad1, pad2, pad3;
     }
 }

--- a/DBFileReaderLib/HotfixReader.cs
+++ b/DBFileReaderLib/HotfixReader.cs
@@ -104,7 +104,7 @@ namespace DBFileReaderLib
             }
         }
 
-        private static RowOp DefaultProcessor(IHotfixEntry row, bool shouldDelete)
+        public static RowOp DefaultProcessor(IHotfixEntry row, bool shouldDelete)
         {
             if (row.IsValid & row.DataSize > 0)
                 return RowOp.Add;

--- a/DBFileReaderLib/HotfixReader.cs
+++ b/DBFileReaderLib/HotfixReader.cs
@@ -1,4 +1,5 @@
-﻿using DBFileReaderLib.Readers;
+﻿using DBFileReaderLib.Common;
+using DBFileReaderLib.Readers;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -8,6 +9,8 @@ namespace DBFileReaderLib
 {
     public class HotfixReader
     {
+        public delegate RowOp RowProcessor(IHotfixEntry row, bool shouldDelete);
+
         private readonly HTFXReader _reader;
 
         #region Header
@@ -39,6 +42,9 @@ namespace DBFileReaderLib
 
         public void ApplyHotfixes<T>(IDictionary<int, T> storage, DBReader dbReader) where T : class, new() => ReadHotfixes(storage, dbReader);
 
+        public void ApplyHotfixes<T>(IDictionary<int, T> storage, DBReader dbReader, RowProcessor processor) where T : class, new() 
+            => ReadHotfixes(storage, dbReader, processor);
+
         public void CombineCaches(params string[] files)
         {
             foreach (var file in files)
@@ -61,9 +67,12 @@ namespace DBFileReaderLib
             _reader.Combine(reader);
         }
 
-        protected virtual void ReadHotfixes<T>(IDictionary<int, T> storage, DBReader dbReader) where T : class, new()
+        protected virtual void ReadHotfixes<T>(IDictionary<int, T> storage, DBReader dbReader, RowProcessor processor = null) where T : class, new()
         {
             var fieldCache = typeof(T).GetFields().Select(x => new FieldCache<T>(x)).ToArray();
+
+            if (processor == null)
+                processor = DefaultProcessor;
 
             // Id fields need to be excluded if not inline
             if (dbReader.Flags.HasFlagExt(DB2Flags.Index))
@@ -80,17 +89,36 @@ namespace DBFileReaderLib
             
             foreach (var row in records)
             {
-                if (row.IsValid & row.DataSize > 0)
+                var operation = processor(row, shouldDelete);
+
+                if (operation == RowOp.Add)
                 {
                     T entry = new T();
                     row.GetFields(fieldCache, entry);
                     storage[row.RecordId] = entry;
                 }
-                else if(shouldDelete)
+                else if(operation == RowOp.Delete)
                 {
                     storage.Remove(row.RecordId);
                 }
             }
         }
+
+        private static RowOp DefaultProcessor(IHotfixEntry row, bool shouldDelete)
+        {
+            if (row.IsValid & row.DataSize > 0)
+                return RowOp.Add;
+            else if (shouldDelete)
+                return RowOp.Delete;
+            else
+                return RowOp.Ignore;
+        }
+    }
+
+    public enum RowOp
+    {
+        Add,
+        Delete,
+        Ignore
     }
 }


### PR DESCRIPTION
As per our conversation yesterday (and not being motivated to do actual work today), I've had a crack at exposing hotfix processing so wow.tools, and anyone else, can override how and if they get applied. When calling `ApplyingHotifixes` you can now pass a delegate that determines how a row is treated (Add, Delete or Ignore). If no delegate is passed then hotfixes work as they do currently. I'm a bit iffy on the naming conventions however I *think* this is a good approach?

I've also tidied up v7 hotfixes so `IsValid` is only true when the op is 1 (previously 2 and 3 were setting this to true).

e.g.

```c#
// the delegate
public delegate RowOp RowProcessor(IHotfixEntry row, bool shouldDelete);

// inline func
storage.ApplyingHotfixes(hotfixReader, (row, shouldDelete) => {
   if (row.IsValid & row.DataSize > 0)
      return RowOp.Add;
   else if (shouldDelete)
      return RowOp.Delete;
   else
      return RowOp.Ignore;
});

// method
storage.ApplyingHotfixes(hotfixReader, ValidateRow);

private static RowOp ValidateRow(IHotfixEntry row, bool shouldDelete)
{
   if (row.IsValid & row.DataSize > 0)
      return RowOp.Add;
   else if (shouldDelete)
      return RowOp.Delete;
   else
      return RowOp.Ignore;
}
```
