### PR TITLE
Implement support for DBCache V8 and workaround for in-between version

### DIFF
--- a/DBFileReaderLib/Common/HTFXStructs.cs
+++ b/DBFileReaderLib/Common/HTFXStructs.cs
@@ -49,4 +49,17 @@ namespace DBFileReaderLib.Common
 
         private readonly byte op, pad1, pad2, pad3;
     }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct HotfixEntryV8 : IHotfixEntry
+    {
+        public int PushId { get; }
+        public int UniqueId { get; }
+        public uint TableHash { get; }
+        public int RecordId { get; }
+        public int DataSize { get; }
+        public bool IsValid => op == 1;
+
+        private readonly byte op, pad1, pad2, pad3;
+    }
 }


### PR DESCRIPTION
Seems to work on WoW.tools, would appreciate a read through though. 