### PR TITLE
Use lookups for encrypted ID lists

### DIFF
--- a/DBCD/DBCDStorage.cs
+++ b/DBCD/DBCDStorage.cs
@@ -2,7 +2,6 @@ using DBCD.Helpers;
 
 using DBFileReaderLib;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Dynamic;
@@ -73,7 +72,7 @@ namespace DBCD
         string[] AvailableColumns { get; }
 
         Dictionary<ulong, int> GetEncryptedSections();
-        Dictionary<int, int[]> GetEncryptedIDs();
+        Dictionary<ulong, int[]> GetEncryptedIDs();
 
         IDBCDStorage ApplyingHotfixes(HotfixReader hotfixReader);
         IDBCDStorage ApplyingHotfixes(HotfixReader hotfixReader, HotfixReader.RowProcessor processor);
@@ -124,8 +123,8 @@ namespace DBCD
             while (enumerator.MoveNext())
                 yield return new DynamicKeyValuePair<int>(enumerator.Current.Key, enumerator.Current.Value);
         }
-        
+
         public Dictionary<ulong, int> GetEncryptedSections() => this.reader.GetEncryptedSections();
-        public Dictionary<int, int[]> GetEncryptedIDs() => this.reader.GetEncryptedIDs();
+        public Dictionary<ulong, int[]> GetEncryptedIDs() => this.reader.GetEncryptedIDs();
     }
 }

--- a/DBFileReaderLib/Common/DBStructs.cs
+++ b/DBFileReaderLib/Common/DBStructs.cs
@@ -16,7 +16,7 @@ namespace DBFileReaderLib.Common
     public interface IEncryptionSupportingReader
     {
         List<IEncryptableDatabaseSection> GetEncryptedSections();
-        Dictionary<int, int[]> GetEncryptedIDs();
+        Dictionary<ulong, int[]> GetEncryptedIDs();
     }
 
     struct FieldMetaData

--- a/DBFileReaderLib/DBReader.cs
+++ b/DBFileReaderLib/DBReader.cs
@@ -105,13 +105,13 @@ namespace DBFileReaderLib
             return reader.GetEncryptedSections().ToDictionary(s => s.TactKeyLookup, s => s.NumRecords);
         }
 
-        public Dictionary<int, int[]> GetEncryptedIDs()
+        public Dictionary<ulong, int[]> GetEncryptedIDs()
         {
             var reader = this._reader as IEncryptionSupportingReader;
 
             if (reader == null || reader.GetEncryptedIDs() == null)
             {
-                return new Dictionary<int, int[]>();
+                return new Dictionary<ulong, int[]>();
             }
 
             return reader.GetEncryptedIDs();

--- a/DBFileReaderLib/Readers/BaseEncryptionSupportingReader.cs
+++ b/DBFileReaderLib/Readers/BaseEncryptionSupportingReader.cs
@@ -7,14 +7,14 @@ namespace DBFileReaderLib.Readers
     abstract class BaseEncryptionSupportingReader : BaseReader, IEncryptionSupportingReader
     {
         protected List<IEncryptableDatabaseSection> m_sections;
-        protected Dictionary<int, int[]> m_encryptedIDs;
+        protected Dictionary<ulong, int[]> m_encryptedIDs;
 
         List<IEncryptableDatabaseSection> IEncryptionSupportingReader.GetEncryptedSections()
         {
             return this.m_sections.Where(s => s.TactKeyLookup != 0).ToList();
         }
 
-        Dictionary<int, int[]> IEncryptionSupportingReader.GetEncryptedIDs()
+        Dictionary<ulong, int[]> IEncryptionSupportingReader.GetEncryptedIDs()
         {
             return this.m_encryptedIDs;
         }

--- a/DBFileReaderLib/Readers/WDC4Reader.cs
+++ b/DBFileReaderLib/Readers/WDC4Reader.cs
@@ -289,7 +289,7 @@ namespace DBFileReaderLib.Readers
 
                 var sections = reader.ReadArray<SectionHeaderWDC4>(sectionsCount);
                 this.m_sections = sections.OfType<IEncryptableDatabaseSection>().ToList();
-                this.m_encryptedIDs = new Dictionary<int, int[]>();
+                this.m_encryptedIDs = new Dictionary<ulong, int[]>();
 
                 // field meta data
                 m_meta = reader.ReadArray<FieldMetaData>(FieldsCount);
@@ -324,12 +324,12 @@ namespace DBFileReaderLib.Readers
                 // encrypted IDs
                 for (int i = 0; i < sectionsCount; i++)
                 {
-                    // If tactkey in section header is 0'd out (before the file gets to DBCD), skip these IDs
+                    // If tactkey in section header is 0'd out (before the file gets to DBCD or section is not encrypted), skip these IDs
                     if (sections[i].TactKeyLookup == 0)
                         continue;
 
                     var encryptedIDCount = reader.ReadInt32();
-                    this.m_encryptedIDs.Add(i, reader.ReadArray<int>(encryptedIDCount));
+                    this.m_encryptedIDs.Add(sections[i].TactKeyLookup, reader.ReadArray<int>(encryptedIDCount));
                 }
 
                 int previousStringTableSize = 0, previousRecordCount = 0;


### PR DESCRIPTION
We aren't actually able to tie key lookups to IDs in the current implementation, so this switches it to use the lookup as the key instead of the section index. This only affects WDC4.