### PR TITLE
Handle signed flag for Immediate compression type in WDC1

### DIFF
--- a/DBFileReaderLib/Readers/WDC1Reader.cs
+++ b/DBFileReaderLib/Readers/WDC1Reader.cs
@@ -135,6 +135,8 @@ namespace DBFileReaderLib.Readers
                     }
                 case CompressionType.Immediate:
                     {
+                        if ((columnMeta.Immediate.Flags & 0x1) == 0x1)
+                            return r.ReadValue64Signed(columnMeta.Immediate.BitWidth).GetValue<T>();
                         return r.ReadValue64(columnMeta.Immediate.BitWidth).GetValue<T>();
                     }
                 case CompressionType.Common:


### PR DESCRIPTION
Fixes reading for the Class column in SpellScaling which are supposed to be negative but end up being positive instead. This makes the value match newer WDC2 versions. Might be valid for versions below WDC1.