### PR TITLE
Support db2 files hacked by TrinityCore extractors

### DIFF
--- a/DBFileReaderLib/Readers/WDC4Reader.cs
+++ b/DBFileReaderLib/Readers/WDC4Reader.cs
@@ -329,7 +329,11 @@ namespace DBFileReaderLib.Readers
                         continue;
 
                     var encryptedIDCount = reader.ReadInt32();
-                    this.m_encryptedIDs.Add(sections[i].TactKeyLookup, reader.ReadArray<int>(encryptedIDCount));
+                    var encryptedIDs = reader.ReadArray<int>(encryptedIDCount);
+                    if (this.m_encryptedIDs.TryGetValue(sections[i].TactKeyLookup, out int[] ids))
+                        this.m_encryptedIDs[sections[i].TactKeyLookup] = ids.Concat(encryptedIDs).ToArray();
+                    else
+                        this.m_encryptedIDs.Add(sections[i].TactKeyLookup, encryptedIDs);
                 }
 
                 int previousStringTableSize = 0, previousRecordCount = 0;

--- a/DBFileReaderLib/Readers/WDC5Reader.cs
+++ b/DBFileReaderLib/Readers/WDC5Reader.cs
@@ -332,7 +332,11 @@ namespace DBFileReaderLib.Readers
                         continue;
 
                     var encryptedIDCount = reader.ReadInt32();
-                    this.m_encryptedIDs.Add(sections[i].TactKeyLookup, reader.ReadArray<int>(encryptedIDCount));
+                    var encryptedIDs = reader.ReadArray<int>(encryptedIDCount);
+                    if (this.m_encryptedIDs.TryGetValue(sections[i].TactKeyLookup, out int[] ids))
+                        this.m_encryptedIDs[sections[i].TactKeyLookup] = ids.Concat(encryptedIDs).ToArray();
+                    else
+                        this.m_encryptedIDs.Add(sections[i].TactKeyLookup, encryptedIDs);
                 }
 
                 int previousStringTableSize = 0, previousRecordCount = 0;


### PR DESCRIPTION
Support sections having duplicated TactKeyLookups

Files extracted by TrinityCore tools have overwritten TactKeyLookup to the string "TRINITY" (0x5452494E49545900) instead of being zeroed (I needed to know if a section was encrypted but has been decrypted)