### PR TITLE
Add support for initializing array types in constructrow

### DIFF
--- a/DBCD.Tests/WritingTest.cs
+++ b/DBCD.Tests/WritingTest.cs
@@ -13,8 +13,58 @@ namespace DBCD.Tests
     public class WritingTest
     {
         public static string InputPath { get; } = $"{Directory.GetCurrentDirectory()}\\DBCCache";
-        public static WagoDBCProvider wagoDBCProvider = new();
 
+        public static string OutputPath = $"{Directory.GetCurrentDirectory()}\\tmp";
+
+        public static WagoDBCProvider wagoDBCProvider = new();
+        static GithubDBDProvider githubDBDProvider = new(true);
+
+        [ClassInitialize()]
+        public static void ClassInit(TestContext context)
+        {
+            if (Directory.Exists(OutputPath))
+            {
+                Directory.Delete(OutputPath, true);
+            }
+            Directory.CreateDirectory(OutputPath);
+        }
+
+        [ClassCleanup()]
+        public static void ClassCleanup()
+        {
+            Directory.Delete(OutputPath, true);
+        }
+
+
+        [TestMethod]
+        public void TestWritingNewRowDb2()
+        {
+            DBCD dbcd = new(wagoDBCProvider, githubDBDProvider);
+            IDBCDStorage storage = dbcd.Load("AlliedRace", "9.2.7.45745");
+
+            storage.Add(700000, storage.ConstructRow(700000));
+            storage.Save(Path.Join(OutputPath, "AlliedRace.db2"));
+
+            DBCD localDbcd = new(new FilesystemDBCProvider(OutputPath), githubDBDProvider);
+            IDBCDStorage outputStorage = localDbcd.Load("AlliedRace", "9.2.7.45745");
+
+            Assert.AreEqual(11, outputStorage.Count);
+        }
+
+        [TestMethod]
+        public void TestWritingNewRowDb2WithArrayField()
+        {
+            DBCD dbcd = new(wagoDBCProvider, githubDBDProvider);
+            IDBCDStorage storage = dbcd.Load("ItemDisplayInfo", "9.2.7.45745");
+
+            storage.Add(700000, storage.ConstructRow(700000));
+            storage.Save(Path.Join(OutputPath, "ItemDisplayInfo.db2"));
+
+            DBCD localDbcd = new(new FilesystemDBCProvider(OutputPath), githubDBDProvider);
+            IDBCDStorage outputStorage = localDbcd.Load("ItemDisplayInfo", "9.2.7.45745");
+
+            Assert.AreEqual(116146, outputStorage.Count);
+        }
 
         [TestMethod]
         public void TestWritingAllDB2s()

--- a/DBCD/DBCDStorage.cs
+++ b/DBCD/DBCDStorage.cs
@@ -195,9 +195,7 @@ namespace DBCD
 
         public DBCDRow ConstructRow(int index) {
             T raw = new();
-            var fieldNames = info.availableColumns;
-            var underlyingType = typeof(T);
-            var fields = underlyingType.GetFields();
+            var fields = typeof(T).GetFields();
             // Array Fields need to be initialized to fill their length
             var arrayFields = fields.Where(x => x.FieldType.IsArray);
             foreach (var arrayField in arrayFields)

--- a/DBCD/DBCDStorage.cs
+++ b/DBCD/DBCDStorage.cs
@@ -1,6 +1,7 @@
 using DBCD.Helpers;
 
 using DBCD.IO;
+using DBCD.IO.Attributes;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -8,6 +9,7 @@ using System.Collections.ObjectModel;
 using System.Dynamic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace DBCD
 {
@@ -191,7 +193,32 @@ namespace DBCD
             storage?.Save(filename);
         }
 
-        public DBCDRow ConstructRow(int index) => new DBCDRow(index, new T(), fieldAccessor);
+        public DBCDRow ConstructRow(int index) {
+            T raw = new();
+            var fieldNames = info.availableColumns;
+            var underlyingType = typeof(T);
+            var fields = underlyingType.GetFields();
+            // Array Fields need to be initialized to fill their length
+            var arrayFields = fields.Where(x => x.FieldType.IsArray);
+            foreach (var arrayField in arrayFields)
+            {
+                var count = arrayField.GetCustomAttribute<CardinalityAttribute>().Count;
+                Array rowRecords = Array.CreateInstance(arrayField.FieldType.GetElementType(), count);
+                for (var i = 0; i < count; i++)
+                {
+                    rowRecords.SetValue(Activator.CreateInstance(arrayField.FieldType.GetElementType()), i);
+                }
+                arrayField.SetValue(raw, rowRecords);
+            }
+
+            // String Fields need to be initialized to empty string rather than null;
+            var stringFields = fields.Where(x => x.FieldType == typeof(string));
+            foreach (var stringField in stringFields)
+            {
+                stringField.SetValue(raw, string.Empty);
+            }
+            return new DBCDRow(index, raw, fieldAccessor);
+        }
 
         public Dictionary<int, DBCDRow> ToDictionary()
         {


### PR DESCRIPTION
In the current version of DBCD, constructing a new row and adding it to a storage works perfectly fine for types that consist only of base types that get initialized with their defaults such as in AlliedRace.db2. However for dynamic types that have an array or string types, such as in the ItemDisplayInfo.db2, these types get initialized to null by C#'s default. This results in a null reference upon writing unless they are properly initialized by the consumer. 

This PR adds the initialization code for an array and string type into the ConstructRow() call, so that a consumer does not need to worry about proper initialization and can use the new row as they would any row that was read from a parser.

I have added two tests to showcase what this PR fixes. The first test 'TestWritingNewRowDb2' adds a constructed row to a simple db2, and passes in the current version of DBCD. The second test 'TestWritingNewRowDb2WithArrayField' fails without the initialization code with a null reference exception.