### PR TITLE
Calling DBCDStorage.Save() twice causes an ArgumentException 

### DIFF
--- a/DBCD.Tests/WritingTest.cs
+++ b/DBCD.Tests/WritingTest.cs
@@ -67,6 +67,15 @@ namespace DBCD.Tests
         }
 
         [TestMethod]
+        public void TestSavingSameStorageTwice()
+        {
+            DBCD dbcd = new(wagoDBCProvider, githubDBDProvider);
+            IDBCDStorage storage = dbcd.Load("AlliedRace", "9.2.7.45745");
+            storage.Save(Path.Join(OutputPath, "AlliedRace.db2"));
+            storage.Save(Path.Join(OutputPath, "AlliedRace.db2"));
+        }
+
+        [TestMethod]
         public void TestWritingAllDB2s()
         {
             return; // Only run this test manually

--- a/DBCD/DBCDStorage.cs
+++ b/DBCD/DBCDStorage.cs
@@ -190,7 +190,8 @@ namespace DBCD
             foreach (var (id, record) in new SortedDictionary<int, DBCDRow>(this))
                 storage.Add(id, record.AsType<T>());
 #endif
-            storage?.Save(filename);
+            storage.Save(filename);
+            storage.Clear();
         }
 
         public DBCDRow ConstructRow(int index) {


### PR DESCRIPTION
Because the Storage<T> is not cleared after a Save() as it is in the constructor for a DBCDStorage, calling this method twice will result in an attempt to add the same keys to the underlying dictionary, which causes an ArgumentException.

This PR fixes the ArgumentException by clearing the Storage after the Save() operation similar to how it is cleared in the constructor after loading. 

See also the added test for the minimal reproducible scenario this PR fixes, current test will fail with an ArgumentException in DBCD 2.0.1.