### PR TITLE
Fix deletion hotfixes not applying

### DIFF
--- a/DBCD/DBCDStorage.cs
+++ b/DBCD/DBCDStorage.cs
@@ -144,8 +144,6 @@ namespace DBCD
 
             foreach (var record in storage)
                 base.Add(record.Key, new DBCDRow(record.Key, record.Value, fieldAccessor));
-
-            storage.Clear();
         }
 
         public void ApplyingHotfixes(HotfixReader hotfixReader)
@@ -166,7 +164,7 @@ namespace DBCD
             foreach (var (id, row) in mutableStorage)
                 base[id] = new DBCDRow(id, row, fieldAccessor);
 #endif
-            foreach (var key in mutableStorage.Keys.Except(base.Keys))
+            foreach (var key in base.Keys.Except(mutableStorage.Keys))
                 base.Remove(key);
         }
 
@@ -194,7 +192,8 @@ namespace DBCD
             storage.Clear();
         }
 
-        public DBCDRow ConstructRow(int index) {
+        public DBCDRow ConstructRow(int index)
+        {
             T raw = new();
             var fields = typeof(T).GetFields();
             // Array Fields need to be initialized to fill their length

--- a/DBCD/DBCDStorage.cs
+++ b/DBCD/DBCDStorage.cs
@@ -180,6 +180,7 @@ namespace DBCD
 
         public void Save(string filename)
         {
+            storage.Clear();
 #if NETSTANDARD2_0
             var sortedDictionary = new SortedDictionary<int, DBCDRow>(this);
             foreach (var record in sortedDictionary)
@@ -189,7 +190,6 @@ namespace DBCD
                 storage.Add(id, record.AsType<T>());
 #endif
             storage.Save(filename);
-            storage.Clear();
         }
 
         public DBCDRow ConstructRow(int index)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <DebugType>embedded</DebugType>
     <LangVersion>latest</LangVersion>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>WoWDev</Authors>


### PR DESCRIPTION
Fixes an issue introduced in 2.0.0. 

Deletion hotfixes would no longer affect anything and other hotfixes would be applied to an otherwise empty storage, probably causing various other issues as well.