### PR TITLE
Fix Reference Data writing in WDC1 / WDC2

### DIFF
--- a/DBCD.IO/Writers/WDC1Writer.cs
+++ b/DBCD.IO/Writers/WDC1Writer.cs
@@ -55,27 +55,30 @@ namespace DBCD.IO.Writers
 
                 int fieldIndex = i - indexFieldOffSet;
 
-                // relationship field, used for faster lookup on IDs
-                if (info.IsNonInlineRelation)
+                // reference data field
+                if (fieldIndex >= m_writer.Meta.Length)
                 {
                     m_writer.ReferenceData.Add((int)Convert.ChangeType(info.Getter(row), typeof(int)));
+                    continue;
+                }
+
+                // relationship field, used for faster lookup on IDs
+                if (info.IsRelation)
+                    m_writer.ReferenceData.Add((int)Convert.ChangeType(info.Getter(row), typeof(int)));
+
+                if (info.IsArray)
+                {
+                    if (arrayWriters.TryGetValue(info.FieldType, out var writer))
+                        writer(bitWriter, m_writer, m_fieldMeta[fieldIndex], ColumnMeta[fieldIndex], PalletData[fieldIndex], CommonData[fieldIndex], (Array)info.Getter(row));
+                    else
+                        throw new Exception("Unhandled array type: " + typeof(T).Name);
                 }
                 else
                 {
-                    if (info.IsArray)
-                    {
-                        if (arrayWriters.TryGetValue(info.FieldType, out var writer))
-                            writer(bitWriter, m_writer, m_fieldMeta[fieldIndex], ColumnMeta[fieldIndex], PalletData[fieldIndex], CommonData[fieldIndex], (Array)info.Getter(row));
-                        else
-                            throw new Exception("Unhandled array type: " + typeof(T).Name);
-                    }
+                    if (simpleWriters.TryGetValue(info.FieldType, out var writer))
+                        writer(id, bitWriter, m_writer, m_fieldMeta[fieldIndex], ColumnMeta[fieldIndex], PalletData[fieldIndex], CommonData[fieldIndex], info.Getter(row));
                     else
-                    {
-                        if (simpleWriters.TryGetValue(info.FieldType, out var writer))
-                            writer(id, bitWriter, m_writer, m_fieldMeta[fieldIndex], ColumnMeta[fieldIndex], PalletData[fieldIndex], CommonData[fieldIndex], info.Getter(row));
-                        else
-                            throw new Exception("Unhandled field type: " + typeof(T).Name);
-                    }
+                        throw new Exception("Unhandled field type: " + typeof(T).Name);
                 }
             }
 


### PR DESCRIPTION
This PR adds the logic for Reference Data from WDC3Writer to WDC1Writer and WDC2Writer. In the current version of the writers, reference data will is omitted for tables that reference another table but are written inline. An example of this behavior can be found in the ItemModifiedAppearance.db2 from 7.3.5.26972.