### PR TITLE
Feature - Extra metadata in constructed type and DBCDStorage

### DIFF
--- a/DBCD.IO/Attributes/ForeignReferenceAttribute.cs
+++ b/DBCD.IO/Attributes/ForeignReferenceAttribute.cs
@@ -1,0 +1,16 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DBCD.IO.Attributes
+{
+    public class ForeignReferenceAttribute : Attribute
+    {
+        public readonly string ForeignTable;
+        public readonly string ForeignColumn;
+
+        public ForeignReferenceAttribute(string foreignTable, string foreignColumn) => (ForeignTable, ForeignColumn) = (foreignTable, foreignColumn);
+
+    }
+}

--- a/DBCD.IO/Attributes/SizeInBitsAttribute.cs
+++ b/DBCD.IO/Attributes/SizeInBitsAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DBCD.IO.Attributes
+{
+    public class SizeInBitsAttribute: Attribute
+    {
+        public readonly ushort Size;
+
+        public SizeInBitsAttribute(ushort size) => Size = size;
+    }
+}

--- a/DBCD.IO/DBParser.cs
+++ b/DBCD.IO/DBParser.cs
@@ -5,6 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("DBCD")]
 
 namespace DBCD.IO
 {
@@ -23,6 +26,7 @@ namespace DBCD.IO
         public uint LayoutHash => _reader.LayoutHash;
         public int IdFieldIndex => _reader.IdFieldIndex;
         public DB2Flags Flags => _reader.Flags;
+        internal ColumnMetaData[] ColumnMeta => _reader.ColumnMeta;
         #endregion
 
         public DBParser(string fileName) : this(File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read)) { }

--- a/DBCD/DBCDBuilder.cs
+++ b/DBCD/DBCDBuilder.cs
@@ -77,6 +77,7 @@ namespace DBCD
             var columns = new List<string>(fields.Length);
             bool localiseStrings = locale != Locale.None;
 
+            var metadataIndex = 0;
             foreach (var fieldDefinition in fields)
             {
                 var columnDefinition = databaseDefinition.columnDefinitions[fieldDefinition.name];
@@ -100,6 +101,15 @@ namespace DBCD
                 if (fieldDefinition.isID)
                 {
                     AddAttribute<IndexAttribute>(field, fieldDefinition.isNonInline);
+                } 
+                
+                if (!fieldDefinition.isNonInline)
+                {
+                    if (metadataIndex < dbcReader.ColumnMeta.Length)
+                    {
+                        AddAttribute<SizeInBitsAttribute>(field, dbcReader.ColumnMeta[metadataIndex].Size);
+                    }
+                    metadataIndex++;
                 }
 
                 if (fieldDefinition.arrLength > 1)

--- a/DBCD/DBCDBuilder.cs
+++ b/DBCD/DBCDBuilder.cs
@@ -113,6 +113,11 @@ namespace DBCD
                     AddAttribute<RelationAttribute>(field, metaDataFieldType, fieldDefinition.isNonInline);
                 }
 
+                if (!string.IsNullOrEmpty(columnDefinition.foreignTable))
+                {
+                    AddAttribute<ForeignReferenceAttribute>(field, columnDefinition.foreignTable, columnDefinition.foreignColumn);
+                }
+
                 if (isLocalisedString)
                 {
                     if (localiseStrings)

--- a/DBCD/DBCDStorage.cs
+++ b/DBCD/DBCDStorage.cs
@@ -107,6 +107,7 @@ namespace DBCD
     public interface IDBCDStorage : IEnumerable<DynamicKeyValuePair<int>>, IDictionary<int, DBCDRow>
     {
         string[] AvailableColumns { get; }
+        uint LayoutHash { get;  }
 
         DBCDRow ConstructRow(int index);
 
@@ -129,6 +130,7 @@ namespace DBCD
         private readonly DBParser parser;
 
         string[] IDBCDStorage.AvailableColumns => this.info.availableColumns;
+        public uint LayoutHash => this.storage.LayoutHash;
         public override string ToString() => $"{this.info.tableName}";
 
         public DBCDStorage(Stream stream, DBCDInfo info) : this(new DBParser(stream), info) { }
@@ -145,6 +147,7 @@ namespace DBCD
             foreach (var record in storage)
                 base.Add(record.Key, new DBCDRow(record.Key, record.Value, fieldAccessor));
         }
+
 
         public void ApplyingHotfixes(HotfixReader hotfixReader)
         {


### PR DESCRIPTION
This PR adds in three pieces of metadata for consumers of DBCD:

- Table and Column referenced by a reference field with a ForeignReferenceAttribute on the type's field.
- Size in bits allocated to a column in WDC formats via ColumnMeta with a SizeInBitsAttribute on type's field.
- The LayoutHash belonging to a DBCDStorage instance.

This is a metadata I am particularly interested for the WDBXEditor2 to be able to provide extra information in the editor and possibly limit the allowed size of integers for instance. I think these pieces of metadata could be generally useful to consumers of DBCD and fits in with the other metadata provided via Attributes atm.

