### PR TITLE
Fix System.MissingMethodException on constructing a row with a string[]

### DIFF
--- a/DBCD.Tests/WritingTest.cs
+++ b/DBCD.Tests/WritingTest.cs
@@ -67,6 +67,21 @@ namespace DBCD.Tests
         }
 
         [TestMethod]
+        public void TestWritingNewRowDb2WithArrayOfStringsField()
+        {
+            DBCD dbcd = new(wagoDBCProvider, githubDBDProvider);
+            IDBCDStorage storage = dbcd.Load("BattlePetEffectProperties", "9.2.7.45745");
+
+            storage.Add(10, storage.ConstructRow(10));
+            storage.Save(Path.Join(OutputPath, "BattlePetEffectProperties.db2"));
+
+            DBCD localDbcd = new(new FilesystemDBCProvider(OutputPath), githubDBDProvider);
+            IDBCDStorage outputStorage = localDbcd.Load("BattlePetEffectProperties", "9.2.7.45745");
+
+            Assert.AreEqual(134, outputStorage.Count);
+        }
+
+        [TestMethod]
         public void TestSavingSameStorageTwice()
         {
             DBCD dbcd = new(wagoDBCProvider, githubDBDProvider);

--- a/DBCD/DBCDStorage.cs
+++ b/DBCD/DBCDStorage.cs
@@ -204,10 +204,19 @@ namespace DBCD
             foreach (var arrayField in arrayFields)
             {
                 var count = arrayField.GetCustomAttribute<CardinalityAttribute>().Count;
-                Array rowRecords = Array.CreateInstance(arrayField.FieldType.GetElementType(), count);
+                var elementType = arrayField.FieldType.GetElementType();
+                var isStringField = elementType == typeof(string);
+
+                Array rowRecords = Array.CreateInstance(elementType, count);
                 for (var i = 0; i < count; i++)
                 {
-                    rowRecords.SetValue(Activator.CreateInstance(arrayField.FieldType.GetElementType()), i);
+                    if (isStringField)
+                    {
+                        rowRecords.SetValue(string.Empty, i);
+                    } else
+                    {
+                        rowRecords.SetValue(Activator.CreateInstance(elementType), i);
+                    }
                 }
                 arrayField.SetValue(raw, rowRecords);
             }


### PR DESCRIPTION
This fixes an exception that is thrown when trying to call the .ConstructRow method for a .db2 file that has an array of strings in its definition such as for the BattlePetEffectProperties.db2 in 9.2.7.45745.

Current code in the added testcase fails with the following exception: 
`System.MissingMethodException: 'Cannot dynamically create an instance of type 'System.String'. Reason: Uninitialized Strings cannot be created.'`

After changes the above exception no longer occurs.

